### PR TITLE
Create DrawPipelineStage.kt

### DIFF
--- a/app/src/main/java/dk/scuffed/whiteboardapp/opengl/OpenGLView.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/opengl/OpenGLView.kt
@@ -2,6 +2,9 @@ package dk.scuffed.whiteboardapp.opengl
 
 import android.content.Context
 import android.opengl.GLSurfaceView
+import android.util.Log
+import android.view.MotionEvent
+import dk.scuffed.whiteboardapp.pipeline.stages.DrawPipelineStage
 
 class OpenGLView(context: Context) : GLSurfaceView(context) {
     init {
@@ -10,5 +13,12 @@ class OpenGLView(context: Context) : GLSurfaceView(context) {
         val renderer = PipelinedOpenGLRenderer(context)
 
         setRenderer(renderer)
+    }
+
+    override fun onTouchEvent(event: MotionEvent?): Boolean {
+        if (event?.action == MotionEvent.ACTION_DOWN) {
+            DrawPipelineStage.next()
+        }
+        return true
     }
 }

--- a/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/Pipeline.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/Pipeline.kt
@@ -143,9 +143,9 @@ class Pipeline(context: Context) {
         )
         */
 
-        DrawFramebufferStage(
+        DrawPipelineStage(
             context,
-            sobelStage.frameBufferInfo,
+            stages,
             this
         )
     }

--- a/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/DrawPipelineStage.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/DrawPipelineStage.kt
@@ -1,0 +1,111 @@
+package dk.scuffed.whiteboardapp.pipeline.stages
+
+import android.content.Context
+import android.opengl.GLES20
+import android.opengl.GLUtils
+import android.util.Log
+import android.util.Size
+import androidx.fragment.app.FragmentManager
+import dk.scuffed.whiteboardapp.R
+import dk.scuffed.whiteboardapp.opengl.*
+import dk.scuffed.whiteboardapp.pipeline.*
+import dk.scuffed.whiteboardapp.pipeline.FramebufferInfo
+import dk.scuffed.whiteboardapp.pipeline.GLOutputStage
+import dk.scuffed.whiteboardapp.pipeline.TextureUnitPair
+
+internal class DrawPipelineStage(
+    context: Context,
+    private val stages: MutableList<Stage>,
+    private val pipeline: Pipeline) : GLOutputStage(context, R.raw.vertex_shader, R.raw.passthrough_shader, pipeline)
+{
+
+    // TODO Get this from the view.
+    private val resolution: Size = Size(1080, 1920)
+
+    private var currentStageIndex: Int
+
+    // Framebuffer used for drawing bitmaps into to throw into the GLOutput
+    private var bitmapFramebuffer: FramebufferInfo
+
+    init {
+        setup()
+        currentStageIndex = stages.lastIndex
+        bitmapFramebuffer = allocateBitmapTexture()
+    }
+
+    override fun setupFramebufferInfo() {
+        // Set framebuffer to screen
+        frameBufferInfo = FramebufferInfo(0, 0, TextureUnitPair(0, 0), 0, resolution)
+    }
+
+    /// Go to the next stage in the pipeline, looping if reaching the end.
+    fun nextStage() {
+        currentStageIndex++
+        if (currentStageIndex > stages.lastIndex) {
+            currentStageIndex = 0
+        }
+        // Cant show itself!
+        if (stages[currentStageIndex] == this) {
+            nextStage()
+        }
+    }
+
+    /// Go to the previous stage in the pipeline, looping if reaching the end.
+    fun prevStage() {
+        currentStageIndex--
+        if (currentStageIndex < 0) {
+            currentStageIndex = stages.lastIndex
+        }
+        // Cant show itself!
+        if (stages[currentStageIndex] == this) {
+            prevStage()
+        }
+    }
+
+    override fun setupUniforms(program: Int) {
+        super.setupUniforms(program)
+
+
+        var inputFrameBufferInfo: FramebufferInfo? = null
+        val currentStage = stages[currentStageIndex]
+        if (currentStage is GLOutputStage) {
+            inputFrameBufferInfo = currentStage.frameBufferInfo
+        }
+        else if (currentStage is BitmapOutputStage) {
+            glActiveTexture(bitmapFramebuffer.textureUnitPair.textureUnit)
+            glBindTexture(GLES20.GL_TEXTURE_2D, bitmapFramebuffer.textureHandle)
+            GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, currentStage.outputBitmap, 0)
+            inputFrameBufferInfo = bitmapFramebuffer
+        }
+        else {
+            Log.d("dsf", "This stage does not support debug viewing")
+        }
+
+        if (inputFrameBufferInfo != null) {
+            // Input framebuffer resolution
+            val framebufferResolutionHandle = glGetUniformLocation(program, "framebuffer_resolution")
+            glUniform2f(framebufferResolutionHandle, inputFrameBufferInfo.textureSize.width.toFloat(), inputFrameBufferInfo.textureSize.height.toFloat())
+
+            // Input framebuffer
+            val framebufferTextureHandle = glGetUniformLocation(program, "framebuffer")
+            glUniform1i(framebufferTextureHandle, inputFrameBufferInfo.textureUnitPair.textureUnitIndex)
+            glActiveTexture(inputFrameBufferInfo.textureUnitPair.textureUnit)
+            glBindTexture(GLES20.GL_TEXTURE_2D, inputFrameBufferInfo.textureHandle)
+        }
+    }
+
+    private fun allocateBitmapTexture() : FramebufferInfo{
+        val textureUnitPair = pipeline.allocateTextureUnit(this)
+        glActiveTexture(textureUnitPair.textureUnit)
+
+        val textureHandle = glGenTexture()
+        glBindTexture(GLES20.GL_TEXTURE_2D, textureHandle)
+        glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR)
+        glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR)
+        glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE)
+        glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE)
+        glBindTexture(GLES20.GL_TEXTURE_2D, 0)
+        return FramebufferInfo(999, textureHandle, textureUnitPair, GLES20.GL_RGBA, Size(resolution.width, resolution.height))
+    }
+
+}

--- a/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/DrawPipelineStage.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/DrawPipelineStage.kt
@@ -46,7 +46,7 @@ internal class DrawPipelineStage(
     init {
         SetStage(this)
         setup()
-        currentStageIndex = stages.lastIndex
+        currentStageIndex = stages.lastIndex - 1
         bitmapFramebuffer = allocateBitmapTexture()
     }
 

--- a/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/DrawPipelineStage.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/DrawPipelineStage.kt
@@ -5,6 +5,8 @@ import android.opengl.GLES20
 import android.opengl.GLUtils
 import android.util.Log
 import android.util.Size
+import android.view.View.OnTouchListener
+import android.view.ViewTreeObserver.OnTouchModeChangeListener
 import androidx.fragment.app.FragmentManager
 import dk.scuffed.whiteboardapp.R
 import dk.scuffed.whiteboardapp.opengl.*
@@ -19,6 +21,20 @@ internal class DrawPipelineStage(
     private val pipeline: Pipeline) : GLOutputStage(context, R.raw.vertex_shader, R.raw.passthrough_shader, pipeline)
 {
 
+    companion object {
+        private var pipelinestage: DrawPipelineStage? = null
+
+        private fun SetStage(stage: DrawPipelineStage){
+            pipelinestage = stage
+        }
+        fun next(){
+            pipelinestage?.nextStage()
+        }
+        fun prev(){
+            pipelinestage?.prevStage()
+        }
+    }
+
     // TODO Get this from the view.
     private val resolution: Size = Size(1080, 1920)
 
@@ -28,6 +44,7 @@ internal class DrawPipelineStage(
     private var bitmapFramebuffer: FramebufferInfo
 
     init {
+        SetStage(this)
         setup()
         currentStageIndex = stages.lastIndex
         bitmapFramebuffer = allocateBitmapTexture()


### PR DESCRIPTION
Allows showing any stage of the pipeline (Including bitmap stages), by throwing it at the end instead of drawFramebufferStage.
