### PR TITLE
Fix biggest square

### DIFF
--- a/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/Utils.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/Utils.kt
@@ -2,6 +2,8 @@ package dk.scuffed.whiteboardapp.pipeline
 
 import android.content.Context
 import com.google.common.io.ByteStreams
+import dk.scuffed.whiteboardapp.utils.Vec2Float
+import kotlin.math.abs
 
 fun readRawResource(context: Context, resourceId: Int): String {
     val stream =
@@ -10,4 +12,9 @@ fun readRawResource(context: Context, resourceId: Int): String {
     stream.close()
 
     return string
+}
+
+// https://www.mathopenref.com/coordtrianglearea.html
+fun areaOfTriangle(a: Vec2Float, b: Vec2Float, c: Vec2Float): Float {
+    return abs((a.x * (b.y - c.y) + b.x * (c.y - a.y) + c.x * (a.y - b.y)) / 2.0f)
 }

--- a/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/bitmap_process_stages/OpenCVLineDetectionStage.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/bitmap_process_stages/OpenCVLineDetectionStage.kt
@@ -40,7 +40,6 @@ internal class OpenCVLineDetectionStage(private val bitmapOutputStage: BitmapOut
 
             lines.add(LineFloat(pt1, pt2))
         }
-        Log.d("LINES", "Found ${lines.size} lines!")
 
         linesMat.release()
         grayMat.release()

--- a/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/lines_stages/BiggestSquareStage.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/lines_stages/BiggestSquareStage.kt
@@ -3,21 +3,18 @@ package dk.scuffed.whiteboardapp.pipeline.stages.lines_stages
 import dk.scuffed.whiteboardapp.pipeline.Pipeline
 import dk.scuffed.whiteboardapp.pipeline.stages.LinesOutputStage
 import dk.scuffed.whiteboardapp.pipeline.stages.PointsOutputStage
+import dk.scuffed.whiteboardapp.utils.QuadFloat
 import dk.scuffed.whiteboardapp.utils.Vec2Float
 import dk.scuffed.whiteboardapp.utils.Vec2Int
 import java.util.*
-import kotlin.math.abs
 
 internal class BiggestSquareStage(private val horizontalLinesStage: LinesOutputStage, private val verticalLinesStage: LinesOutputStage, pipeline: Pipeline) :
-    PointsOutputStage(pipeline, Vec2Int(0, 0)) {
+    PointsOutputStage(pipeline, Vec2Int(0, 0), Vec2Int(0, 0), Vec2Int(0,0), Vec2Int(0,0)) {
+
     override fun update() {
-        var bestA = Vec2Float(0f,0f)
-        var bestB = Vec2Float(0f,0f)
-        var bestC = Vec2Float(0f,0f)
-        var bestD = Vec2Float(0f,0f)
+        var bestQuad = QuadFloat()
         var bestArea = 0f
 
-        points.clear()
         for (x1 in 0 until horizontalLinesStage.lines.size) {
             for (x2 in x1+1 until horizontalLinesStage.lines.size) {
                 for (y1 in 0 until verticalLinesStage.lines.size) {
@@ -27,116 +24,111 @@ internal class BiggestSquareStage(private val horizontalLinesStage: LinesOutputS
                         val ly1 = verticalLinesStage.lines[y1]
                         val ly2 = verticalLinesStage.lines[y2]
 
-                        lx1.intersect(ly1)?.let { p1 ->
-                            lx1.intersect(ly2)?.let { p2 ->
-                                lx2.intersect(ly1)?.let { p3 ->
-                                    lx2.intersect(ly2)?.let { p4 ->
-                                        val ps = convexHull(arrayOf(p1, p2, p3, p4))
-                                        ps?.let {
-                                            val a = it[0]
-                                            val b = it[1]
-                                            val c = it[2]
-                                            val d = it[3]
+                        val p1 = lx1.intersect(ly1)
+                        val p2 = lx1.intersect(ly2)
+                        val p3 = lx2.intersect(ly1)
+                        val p4 = lx2.intersect(ly2)
 
-                                            val area = areaOfTriangle(a, b, c) + areaOfTriangle(a, c, d)
+                        if (p1 != null && p2 != null && p3 != null && p4 != null) {
+                            val quad = makeQuadConvex(QuadFloat(p1, p2, p3, p4))
 
-                                            if (area > bestArea) {
-                                                bestA = a
-                                                bestB = b
-                                                bestC = c
-                                                bestD = d
-                                                bestArea = area
-                                            }
-                                        }
-                                    }
-                                }
+                            val area = quad.area()
+                            if (area > bestArea) {
+                                bestQuad = quad
+                                bestArea = area
                             }
                         }
-
                     }
                 }
             }
         }
 
-        points.add(bestA.toVec2Int())
-        points.add(bestB.toVec2Int())
-        points.add(bestC.toVec2Int())
-        points.add(bestD.toVec2Int())
-    }
+        // Use the last found quad if we don't detect any
+        if (bestArea != 0f) {
+            val fixedQuad = fixupQuad(bestQuad)
 
-    // To find orientation of ordered triplet (p, q, r).
-    // The function returns following values
-    // 0 --> p, q and r are collinear
-    // 1 --> Clockwise
-    // 2 --> Counterclockwise
-    fun orientation(p: Vec2Float, q: Vec2Float, r: Vec2Float): Int {
-        val v = (q.y - p.y) * (r.x - q.x) -
-                (q.x - p.x) * (r.y - q.y)
-        if (v == 0.0f) return 0 // collinear
-        return if (v > 0) 1 else 2 // clock or counterclock wise
-    }
-
-    // Prints convex hull of a set of n points.
-    fun convexHull(points: Array<Vec2Float>): Array<Vec2Float>? {
-        val n = points.size
-        // There must be at least 3 points
-        if (n < 3) return null
-
-        // Initialize Result
-        val hull = Vector<Vec2Float>()
-
-        // Find the leftmost point
-        var l = 0
-        for (i in 1 until n) if (points[i].x < points[l].x) l = i
-
-        // Start from leftmost point, keep moving
-        // counterclockwise until reach the start point
-        // again. This loop runs O(h) times where h is
-        // number of points in result or output.
-        var p = l
-        var q: Int
-        do {
-            // Add current point to result
-            hull.add(points[p])
-
-            // Search for a point 'q' such that
-            // orientation(p, q, x) is counterclockwise
-            // for all points 'x'. The idea is to keep
-            // track of last visited most counterclock-
-            // wise point in q. If any point 'i' is more
-            // counterclock-wise than q, then update q.
-            q = (p + 1) % n
-            for (i in 0 until n) {
-                // If i is more counterclockwise than
-                // current q, then update q
-                if (orientation(points[p], points[i], points[q])
-                    == 2
-                ) q = i
-            }
-
-            // Now q is the most counterclockwise with
-            // respect to p. Set p as q for next iteration,
-            // so that q is added to result 'hull'
-            p = q
-        } while (p != l) // While we don't come to first
-        // point
-
-        /*
-        var thing = "New points!\n"
-        // Print Result
-        for (temp: Vec2Float in hull) {
-            thing +=
-            (("(" + temp.x) + ", " +
-                    temp.y) + ")\n"
+            points[0] = fixedQuad.a.toVec2Int()
+            points[1] = fixedQuad.b.toVec2Int()
+            points[2] = fixedQuad.c.toVec2Int()
+            points[3] = fixedQuad.d.toVec2Int()
         }
-        Log.d("POINTS", thing)
-         */
-
-        return hull.toTypedArray()
     }
 
-    // https://www.mathopenref.com/coordtrianglearea.html
-    private fun areaOfTriangle(a: Vec2Float, b: Vec2Float, c: Vec2Float): Float {
-        return abs((a.x * (b.y - c.y) + b.x * (c.y - a.y) + c.x * (a.y - b.y)) / 2.0f)
+    // The point a should be the top left corner
+    // The quad should be counter-clockwise
+    private fun fixupQuad(quad: QuadFloat): QuadFloat {
+        val points = ArrayList(listOf(*quad.toVec2FloatArray()))
+
+        var bottomLeftPoint: Vec2Float? = null
+        for (point in points) {
+            if (bottomLeftPoint == null) {
+                bottomLeftPoint = point
+            }
+            else if (point.x + point.y < bottomLeftPoint.x + bottomLeftPoint.y) {
+                bottomLeftPoint = point
+            }
+        }
+
+        points.remove(bottomLeftPoint)
+
+        var bottomRightPoint: Vec2Float? = null
+        for (point in points) {
+            if (bottomRightPoint == null) {
+                bottomRightPoint = point
+            }
+            else if ((-point.x) + point.y < (-bottomRightPoint.x) + bottomRightPoint.y ) {
+                bottomRightPoint = point
+            }
+        }
+
+        points.remove(bottomRightPoint)
+
+        var topRightPoint: Vec2Float? = null
+        for (point in points) {
+            if (topRightPoint == null) {
+                topRightPoint = point
+            }
+            else if (point.x + point.y > topRightPoint.x + topRightPoint.y) {
+                topRightPoint = point
+            }
+        }
+
+        points.remove(topRightPoint)
+
+        val topLeftPoint = points[0]
+
+        return QuadFloat(topLeftPoint, bottomLeftPoint!!, bottomRightPoint!!, topRightPoint!!)
+    }
+
+    private fun makeQuadConvex(quad: QuadFloat): QuadFloat {
+        val points = ArrayList(listOf(*quad.toVec2FloatArray()))
+
+        val a = points[0]
+        points.remove(a)
+
+        val b = shortestDistance(a, points)
+        points.remove(b)
+
+        val c = shortestDistance(b, points)
+        points.remove(c)
+
+        val d = points[0]
+
+        return QuadFloat(a, b, c, d)
+    }
+
+    private fun shortestDistance(point: Vec2Float, points: ArrayList<Vec2Float>): Vec2Float {
+        var shortestDistance = Float.MAX_VALUE
+        var shortestPoint = Vec2Float(0f, 0f)
+
+        for (other in points) {
+            val distance = point.distance(other)
+            if (distance < shortestDistance) {
+                shortestDistance = distance
+                shortestPoint = other
+            }
+        }
+
+        return shortestPoint
     }
 }

--- a/app/src/main/java/dk/scuffed/whiteboardapp/utils/QuadFloat.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/utils/QuadFloat.kt
@@ -1,0 +1,26 @@
+package dk.scuffed.whiteboardapp.utils
+
+import dk.scuffed.whiteboardapp.pipeline.areaOfTriangle
+
+fun QuadFloat(): QuadFloat {
+    return QuadFloat(Vec2Float(0f, 0f), Vec2Float(0f, 0f), Vec2Float(0f, 0f), Vec2Float(0f, 0f))
+}
+
+class QuadFloat(val a: Vec2Float, val b: Vec2Float, val c: Vec2Float, val d: Vec2Float) {
+    fun area(): Float {
+        return areaOfTriangle(a, b, c) + areaOfTriangle(a, c, d);
+    }
+
+    fun toVec2FloatArray(): Array<Vec2Float> {
+        return arrayOf(a, b, c, d)
+    }
+
+    override fun toString(): String {
+        return """
+        a: $a
+        b: $b
+        c: $c
+        d: $d
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
We could not use the convex hull algorithm as it would get stuck if we did not have a convex polygon.

Instead we find the square by taking the shortest distance to the next point until we have all our points.
We use this to calculate the area of the quad and we then find the biggest quad from all possible quads.

The quad is then fixed so it can be used in perspective correction. This is done by taking the most top left corner and then finding the most bottom left corner and so on and so forth.

This gives us a quad that starts in the top left corner and which points has an anti-clockwise direction.