### PR TITLE
Add a ThreadedPipelineStage

### DIFF
--- a/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stage_combinations/FullPipeline.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stage_combinations/FullPipeline.kt
@@ -2,19 +2,15 @@ package dk.scuffed.whiteboardapp.pipeline.stage_combinations
 
 import android.content.Context
 import android.opengl.GLES20
-import dk.scuffed.whiteboardapp.pipeline.FramebufferInfo
 import dk.scuffed.whiteboardapp.pipeline.IPipeline
 import dk.scuffed.whiteboardapp.pipeline.stages.GLOutputStage
-import dk.scuffed.whiteboardapp.pipeline.stages.update_every_x_frames_stages.UpdateEveryXFramesPointsStage
 import dk.scuffed.whiteboardapp.pipeline.stages.opengl_process_stages.*
 import dk.scuffed.whiteboardapp.pipeline.stages.opengl_process_stages.BinarizationStage
 import dk.scuffed.whiteboardapp.pipeline.stages.opengl_process_stages.MaskingStage
 import dk.scuffed.whiteboardapp.pipeline.stages.opengl_process_stages.OverlayStage
 import dk.scuffed.whiteboardapp.pipeline.stages.opengl_process_stages.StoreStage
 import dk.scuffed.whiteboardapp.pipeline.stages.points_stages.DrawCornersStage
-import dk.scuffed.whiteboardapp.pipeline.stages.points_stages.DrawLinesStage
 import dk.scuffed.whiteboardapp.pipeline.stages.points_stages.ScreenCornerPointsStage
-import dk.scuffed.whiteboardapp.utils.Vec2Int
 
 /**
  * Our canonical full pipeline that does everything except input/output
@@ -47,22 +43,12 @@ internal fun fullPipeline(
     )
 
 
-    val cornerDetectionEveryXFrames = UpdateEveryXFramesPointsStage(
-        {
-            fullCornerDetection(context, storeStage, it)
-        },
-        10,
-        pipeline,
-        Vec2Int(0, 0),
-        Vec2Int(0, 0),
-        Vec2Int(0, 0),
-        Vec2Int(0, 0)
-    )
+    val cornerDetectionStage = fullCornerDetection(context, storeStage, pipeline)
 
     val drawCorners = DrawCornersStage(
         context,
         pipeline,
-        cornerDetectionEveryXFrames.getPointsOutputStage()
+        cornerDetectionStage
     )
 
 
@@ -70,7 +56,7 @@ internal fun fullPipeline(
     val perspectiveCorrection = fullPerspectiveCorrection(
         context,
         storeStage,
-        cornerDetectionEveryXFrames.getPointsOutputStage(),
+        cornerDetectionStage,
         screenPointsStage,
         pipeline
     )

--- a/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/pipeline_stages/ThreadedBitmapInputPointOutputStage.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/pipeline_stages/ThreadedBitmapInputPointOutputStage.kt
@@ -1,0 +1,125 @@
+package dk.scuffed.whiteboardapp.pipeline.stages.pipeline_stages
+
+import android.graphics.Bitmap
+import android.util.Size
+import dk.scuffed.whiteboardapp.pipeline.FramebufferInfo
+import dk.scuffed.whiteboardapp.pipeline.IPipeline
+import dk.scuffed.whiteboardapp.pipeline.TextureUnitPair
+import dk.scuffed.whiteboardapp.pipeline.stages.BitmapOutputStage
+import dk.scuffed.whiteboardapp.pipeline.stages.PointsOutputStage
+import dk.scuffed.whiteboardapp.pipeline.stages.Stage
+import dk.scuffed.whiteboardapp.utils.Vec2Int
+
+/**
+ * Takes a BitmapOutputStage as input and runs its stages in a separate thread and outputs it as a point output stage
+ */
+internal class ThreadedBitmapInputPointOutputStage(
+    preliminaryStageConstructor: (pipeline: IPipeline) -> Unit,
+    inputStageConstructor: (inputBitmapStage: BitmapOutputStage, pipeline: IPipeline) -> Unit,
+    pipeline: IPipeline,
+    vararg initialPoints: Vec2Int
+) : ThreadedStageBase(pipeline) {
+    private val myInputBitmapStage: MyInputBitmapStage
+
+    private val outputPointsStage: PointsOutputStage
+    val myOutputPointsStage: PointsOutputStage
+
+    private val myPreliminaryStagesPipeline = MyPreliminaryStagesPipeline(pipeline)
+
+    init {
+        preliminaryStageConstructor(myPreliminaryStagesPipeline)
+
+        val inputBitmap =
+            (myPreliminaryStagesPipeline.stages.last() as BitmapOutputStage).outputBitmap
+        val copiedInputBitmap = inputBitmap.copy(inputBitmap.config, false)
+        myInputBitmapStage = MyInputBitmapStage(
+            manualPipeline,
+            Size(copiedInputBitmap.width, copiedInputBitmap.height),
+            copiedInputBitmap.config
+        )
+        inputStageConstructor(myInputBitmapStage, this)
+        outputPointsStage = stages.last() as PointsOutputStage
+        myOutputPointsStage = MyOutputPointsStage(this, *initialPoints)
+    }
+
+
+    override fun updateInput() {
+        myPreliminaryStagesPipeline.draw()
+
+        val inputBitmap =
+            (myPreliminaryStagesPipeline.stages.last() as BitmapOutputStage).outputBitmap
+        val copiedInputBitmap = inputBitmap.copy(inputBitmap.config, false)
+        myInputBitmapStage.updateBitmap(copiedInputBitmap)
+    }
+
+    override fun updateOutput() {
+        (myOutputPointsStage as MyOutputPointsStage).updatePoints(outputPointsStage.points)
+    }
+
+    override fun whenResolutionChanged(resolution: Size) {
+        super.whenResolutionChanged(resolution)
+
+        myPreliminaryStagesPipeline.onResolutionChanged(resolution)
+
+    }
+
+    private class MyPreliminaryStagesPipeline(private val pipeline: IPipeline) : IPipeline {
+        val stages = ArrayList<Stage>()
+
+        override fun draw() {
+            for (stage in stages) {
+                stage.performUpdate()
+            }
+        }
+
+        override fun onResolutionChanged(resolution: Size) {
+            for (stage in stages) {
+                stage.performOnResolutionChanged(resolution)
+            }
+        }
+
+        override fun getInitialResolution(): Size {
+            return pipeline.getInitialResolution()
+        }
+
+        override fun addStage(stage: Stage) {
+            stages.add(stage)
+        }
+
+        override fun allocateFramebuffer(
+            stage: Stage,
+            textureFormat: Int,
+            size: Size
+        ): FramebufferInfo {
+            return pipeline.allocateFramebuffer(stage, textureFormat, size)
+        }
+
+        override fun allocateTextureUnit(stage: Stage): TextureUnitPair {
+            return pipeline.allocateTextureUnit(stage)
+        }
+    }
+
+    private class MyInputBitmapStage(pipeline: IPipeline, resolution: Size, config: Bitmap.Config) :
+        BitmapOutputStage(pipeline, resolution, config) {
+        override fun update() {
+            // Never call this
+            assert(false)
+        }
+
+        fun updateBitmap(bitmap: Bitmap) {
+            outputBitmap = bitmap
+        }
+    }
+
+    private class MyOutputPointsStage(pipeline: IPipeline, vararg initialPoints: Vec2Int) :
+        PointsOutputStage(pipeline, *initialPoints) {
+        override fun update() {
+            // Don't do anything
+        }
+
+        fun updatePoints(newPoints: ArrayList<Vec2Int>) {
+            points.clear()
+            points.addAll(newPoints)
+        }
+    }
+}

--- a/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/pipeline_stages/ThreadedStageBase.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/pipeline_stages/ThreadedStageBase.kt
@@ -1,0 +1,131 @@
+package dk.scuffed.whiteboardapp.pipeline.stages.pipeline_stages
+
+import android.util.Size
+import dk.scuffed.whiteboardapp.pipeline.FramebufferInfo
+import dk.scuffed.whiteboardapp.pipeline.IPipeline
+import dk.scuffed.whiteboardapp.pipeline.TextureUnitPair
+import dk.scuffed.whiteboardapp.pipeline.stages.GLOutputStage
+import dk.scuffed.whiteboardapp.pipeline.stages.Stage
+import java.util.concurrent.Semaphore
+
+/**
+ * A base class for a pipeline stage that runs its stages in a separate thread
+ */
+internal abstract class ThreadedStageBase(private val pipeline: IPipeline) : Stage(pipeline),
+    IPipeline {
+    protected val stages = ArrayList<Stage>()
+    private val stageThread = Thread({ threadLoop() }, "ThreadedStage Thread")
+    private var stageThreadStarted = false
+    private var hasOutput = false
+
+    private val inputReadySemaphore = Semaphore(0)
+    private val outputReadySemaphore = Semaphore(1)
+
+    protected val manualPipeline: IPipeline = MyManualPipeline(this)
+
+    abstract fun updateInput()
+    abstract fun updateOutput()
+
+    private fun threadLoop() {
+        assert(Thread.currentThread() == stageThread)
+        while (true) {
+            inputReadySemaphore.acquire()
+            draw()
+            outputReadySemaphore.release()
+        }
+    }
+
+    final override fun draw() {
+        assert(Thread.currentThread() == stageThread)
+
+        for (stage in stages) {
+            stage.performUpdate()
+        }
+    }
+
+    final override fun onResolutionChanged(resolution: Size) {
+        TODO("Not yet implemented")
+    }
+
+    final override fun getInitialResolution(): Size {
+        assert(Thread.currentThread() != stageThread)
+        return pipeline.getInitialResolution()
+    }
+
+    final override fun addStage(stage: Stage) {
+        assert(stage !is GLOutputStage)
+        stages.add(stage)
+    }
+
+    final override fun allocateFramebuffer(
+        stage: Stage,
+        textureFormat: Int,
+        size: Size
+    ): FramebufferInfo {
+        assert(Thread.currentThread() != stageThread)
+        return pipeline.allocateFramebuffer(stage, textureFormat, size)
+    }
+
+    final override fun allocateTextureUnit(stage: Stage): TextureUnitPair {
+        assert(Thread.currentThread() != stageThread)
+        return pipeline.allocateTextureUnit(stage)
+    }
+
+    final override fun update() {
+        assert(Thread.currentThread() != stageThread)
+
+        if (!stageThreadStarted) {
+            stageThread.start()
+            stageThreadStarted = true
+        }
+
+        if (outputReadySemaphore.tryAcquire()) {
+            updateInput()
+            if (hasOutput) {
+                updateOutput()
+            }
+            inputReadySemaphore.release()
+            hasOutput = true
+        }
+    }
+
+    override fun whenResolutionChanged(resolution: Size) {
+        super.whenResolutionChanged(resolution)
+
+        manualPipeline.onResolutionChanged(resolution)
+    }
+
+    private class MyManualPipeline(private val pipeline: IPipeline) : IPipeline {
+        private val stages = ArrayList<Stage>()
+
+        override fun draw() {
+            // Don't do anything
+        }
+
+        override fun onResolutionChanged(resolution: Size) {
+            for (stage in stages) {
+                stage.performOnResolutionChanged(resolution)
+            }
+        }
+
+        override fun getInitialResolution(): Size {
+            return pipeline.getInitialResolution()
+        }
+
+        override fun addStage(stage: Stage) {
+            stages.add(stage)
+        }
+
+        override fun allocateFramebuffer(
+            stage: Stage,
+            textureFormat: Int,
+            size: Size
+        ): FramebufferInfo {
+            return pipeline.allocateFramebuffer(stage, textureFormat, size)
+        }
+
+        override fun allocateTextureUnit(stage: Stage): TextureUnitPair {
+            return pipeline.allocateTextureUnit(stage)
+        }
+    }
+}

--- a/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/pipeline_stages/UpdateEveryXFramesPointsStage.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/pipeline_stages/UpdateEveryXFramesPointsStage.kt
@@ -1,4 +1,4 @@
-package dk.scuffed.whiteboardapp.pipeline.stages.update_every_x_frames_stages
+package dk.scuffed.whiteboardapp.pipeline.stages.pipeline_stages
 
 import dk.scuffed.whiteboardapp.pipeline.IPipeline
 import dk.scuffed.whiteboardapp.pipeline.stages.PointsOutputStage

--- a/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/pipeline_stages/UpdateEveryXFramesStageBase.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stages/pipeline_stages/UpdateEveryXFramesStageBase.kt
@@ -1,4 +1,4 @@
-package dk.scuffed.whiteboardapp.pipeline.stages.update_every_x_frames_stages
+package dk.scuffed.whiteboardapp.pipeline.stages.pipeline_stages
 
 import android.util.Size
 import dk.scuffed.whiteboardapp.pipeline.FramebufferInfo


### PR DESCRIPTION
This stage does NOT support GL stages.
This stage is used in fullCornerDetection to do line detection in a seperate thread.
This is out of sync so the framerate of line detection is not the same as the framerate of the rest of the system.
This mitigates the performance penalty of doing line detection.