### PR TITLE
Check the quad from BiggestSquareStage is ok for perspective correction

### DIFF
--- a/app/src/main/java/dk/scuffed/whiteboardapp/utils/IVec.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/utils/IVec.kt
@@ -6,5 +6,7 @@ interface IVec<TVec, TUnderlying> {
     operator fun times(other: TUnderlying): TVec
     operator fun div(other: TUnderlying): TVec
 
+    fun length(): Float
     fun distance(other: TVec): Float
+    fun dot(other: TVec): Float
 }

--- a/app/src/main/java/dk/scuffed/whiteboardapp/utils/Vec2Float.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/utils/Vec2Float.kt
@@ -25,8 +25,16 @@ class Vec2Float(val x: Float, val y: Float) : IVec<Vec2Float, Float> {
         return Vec2Float(x / other, y / other)
     }
 
+    override fun length(): Float {
+        return sqrt(x*x + y*y)
+    }
+
     override fun distance(other: Vec2Float): Float {
         return sqrt((other.x - this.x).pow(2f) + (other.y - this.y).pow(2f))
+    }
+
+    override fun dot(other: Vec2Float): Float {
+        return this.x*other.x + this.y*other.y
     }
 
     fun toVec2Int(): Vec2Int {

--- a/app/src/main/java/dk/scuffed/whiteboardapp/utils/Vec2Int.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/utils/Vec2Int.kt
@@ -25,6 +25,14 @@ class Vec2Int(val x: Int, val y: Int) : IVec<Vec2Int, Int> {
         return Vec2Int(x / other, y / other)
     }
 
+    override fun length(): Float {
+        return sqrt((x*x + y*y).toFloat())
+    }
+
+    override fun dot(other: Vec2Int): Float {
+        return this.x.toFloat()*other.x.toFloat() + this.y.toFloat()*other.y.toFloat()
+    }
+
     override fun distance(other: Vec2Int): Float {
         return sqrt((other.x - this.x).toFloat().pow(2f) + (other.y - this.y).toFloat().pow(2f))
     }

--- a/app/src/main/java/dk/scuffed/whiteboardapp/utils/Vec3Float.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/utils/Vec3Float.kt
@@ -25,6 +25,14 @@ class Vec3Float(val x: Float, val y: Float, val z: Float) : IVec<Vec3Float, Floa
         return Vec3Float(x / other, y / other, z / other)
     }
 
+    override fun length(): Float {
+        return sqrt(x*x + y*y + z*z)
+    }
+
+    override fun dot(other: Vec3Float): Float {
+        return this.x * other.x + this.y * other.y + this.z * other.z
+    }
+
     override fun distance(other: Vec3Float): Float {
         return sqrt(
             (other.x - this.x).pow(2f) + (other.y - this.y).pow(2f) + (other.z - this.z).pow(


### PR DESCRIPTION
We now check that the biggest quad found is perspective correctable. This means that the angles between the points may not go under 60 degrees and must not exceed 130 degrees.

This is not a real solution to check if the quad is perspective correctable. We are probably over approximating here, however it is more important that we don't get invalid quads than that we cannot perspective correct extreme angles.