### PR TITLE
Tune binarization parameters

### DIFF
--- a/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stage_combinations/FullPipeline.kt
+++ b/app/src/main/java/dk/scuffed/whiteboardapp/pipeline/stage_combinations/FullPipeline.kt
@@ -79,8 +79,8 @@ internal fun fullPipeline(
     val binarized = binarize(
         context,
         perspectiveCorrection,
-        7.5f,
-        5,
+        10.0f,
+        3,
         pipeline)
 
     val readdedColour = addColour(


### PR DESCRIPTION
This should also speed up binarization as it has to do less downscaling steps

Before:
![Before](https://user-images.githubusercontent.com/8753257/232441417-da053081-3856-4669-9700-dbd45327a3f5.png)

After:
![After](https://user-images.githubusercontent.com/8753257/232441466-6f5d75b7-5eba-423b-8d53-9f9d4a954efa.png)
